### PR TITLE
adds support for configurable timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.0
+
+- Adds support for open and read timeouts
+
 # v0.0.2
 
 - Fix bug where `:ssl_version` is a string when it should be a symbol

--- a/lib/soap_adapters/savon.rb
+++ b/lib/soap_adapters/savon.rb
@@ -2,13 +2,15 @@ module SoapAdapters
   class Savon
 
     include Virtus.model
-    CLIENT_ATTRS = %i[wsdl logger log ssl_version]
+    CLIENT_ATTRS = %i[wsdl logger log ssl_version open_timeout read_timeout]
 
     attribute :wsdl, String
     attribute :logger
     attribute :log, Boolean, default: true
     attribute :ssl_version, Symbol, default: :TLSv1
     attribute :last_request, String
+    attribute :open_timeout, Integer
+    attribute :read_timeout, Integer
 
     def ssl_version
       @ssl_version || :TLSv1

--- a/lib/soap_adapters/version.rb
+++ b/lib/soap_adapters/version.rb
@@ -1,3 +1,3 @@
 module SoapAdapters
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/spec/lib/soap_adapters/savon_spec.rb
+++ b/spec/lib/soap_adapters/savon_spec.rb
@@ -61,6 +61,21 @@ describe SoapAdapters::Savon do
       expect(r.to_s).to eq "response_xml"
       expect(r.xml).to eq "response_xml"
     end
+
+    it "sets the open_timeout and read_timeout if declared" do
+      allow(::Savon).to receive(:client).with(
+        wsdl: "wsdl",
+        log: false,
+        ssl_version: :TLSv1,
+        open_timeout: 30,
+        read_timeout: 10
+      ).and_return(client)
+      adapter = described_class.new(wsdl: "wsdl", log: false, open_timeout: 30, read_timeout: 10)
+      r = adapter.call(*client_args)
+      expect(adapter.last_request).to eq "request_xml"
+      expect(r.to_s).to eq "response_xml"
+      expect(r.xml).to eq "response_xml"
+    end
   end
 
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/133344711

https://github.com/savonrb/savon/blob/b72ab393684bbd993b747d6529ee96e30d772091/lib/savon/request.rb#L21 shows what happens with `open` and `read` timeout values
